### PR TITLE
fix: Regression in Laravel 5.8

### DIFF
--- a/src/AutoSort.php
+++ b/src/AutoSort.php
@@ -22,7 +22,7 @@ trait AutoSort
                 $column = $temp[1];
 
                 $query->select($this->getTable().'.*');
-                $query->join($table, $relation->getQualifiedForeignKeyName(), '=', $table.".".$relation->getQualifiedOwnerKeyName());
+                $query->join($table, $relation->getQualifiedForeignKeyName(), '=', $relation->getQualifiedOwnerKeyName());
                 $query->orderBy($table.".".$column, $direction);
             } else {
                 $query->orderBy($column, $direction);

--- a/src/AutoSort.php
+++ b/src/AutoSort.php
@@ -22,7 +22,7 @@ trait AutoSort
                 $column = $temp[1];
 
                 $query->select($this->getTable().'.*');
-                $query->join($table, $relation->getForeignKey(), '=', $table.".".$relation->getOwnerKey());
+                $query->join($table, $relation->getQualifiedForeignKeyName(), '=', $table.".".$relation->getQualifiedOwnerKeyName());
                 $query->orderBy($table.".".$column, $direction);
             } else {
                 $query->orderBy($column, $direction);


### PR DESCRIPTION
There is no `getForeignKey()` and `getOwnerKey()` anymore in Laravel 5.8.
And we need to use full qualified column name (column prefixed with table name), to prevent column ambiguous error (`Column 'xxxx' in field list is ambiguous`)